### PR TITLE
add owo token mapping on ethereum

### DIFF
--- a/coins/src/adapters/tokenMapping.json
+++ b/coins/src/adapters/tokenMapping.json
@@ -974,6 +974,11 @@
       "symbol": "MoreXRP",
       "to": "coingecko#ripple"
     },
+    "0x806a72273b961145cf5c5f040ad1fcd112b3f11a": {
+  "decimals": "18",
+  "symbol": "OWO",
+  "to": "coingecko#owo"
+},
     "0xdD468A1DDc392dcdbEf6db6e34E89AA338F9F186": {
       "decimals": "18",
       "symbol": "MUSD",


### PR DESCRIPTION
added mapping for OwO(Emote Frog) on ethereum so prices resolve correctly

token: 0x806a72273b961145cf5c5f040ad1fcd112b3f11a
coingecko: owo

closes #16148
